### PR TITLE
Add AllCapitalCities.ByContinent() method to return all capital cities in a continent by population

### DIFF
--- a/src/main/java/com/napier/sem/App.java
+++ b/src/main/java/com/napier/sem/App.java
@@ -117,6 +117,7 @@ public class App
 
         //---------       All capital cities by population in descending order    ---------------
         keyValues.put("17", () -> app.displayCapitalCities(AllCapitalCities.ByWorld()));
+        keyValues.put("18", () -> app.displayCapitalCities(AllCapitalCities.ByContinent(getN(scanner), continent)));
 
         return keyValues.getOrDefault(choice, () -> System.out.println("Invalid choice."));
     }

--- a/src/main/java/com/napier/sem/Features/AllCapitalCities.java
+++ b/src/main/java/com/napier/sem/Features/AllCapitalCities.java
@@ -17,4 +17,14 @@ public class AllCapitalCities {
                 "WHERE country.capital = city.id " +
                 "ORDER BY city.Population DESC");
     }
+
+    public static ArrayList<City> ByContinent(int N, String continent) {
+        return ReportHelper.getCityReport("SELECT city.Name, country.Name as CountryName, city.District, city.Population " +
+                "FROM city " +
+                "JOIN country ON city.CountryCode = country.Code " +
+                "WHERE country.capital = city.id " +
+                "AND country.Continent = '" + continent + "' " +
+                "ORDER BY city.Population DESC " +
+                "LIMIT " + N);
+    }
 }

--- a/src/main/java/com/napier/sem/View/Index.java
+++ b/src/main/java/com/napier/sem/View/Index.java
@@ -30,5 +30,6 @@ public class Index
         System.out.println("  16)  Top populated cities in a district");
         System.out.println();
         System.out.println("  17)  List of capital cities in the world by population in descending order");
+        System.out.println("  18)  List of capital cities in a continent by population in descending order");
     }
 }

--- a/src/test/java/com/napier/sem/AppTest.java
+++ b/src/test/java/com/napier/sem/AppTest.java
@@ -86,6 +86,7 @@ public class AppTest
         app.displayCities(cities);
     }
 
+    @Test
     void printCapitalCitiesTestNull()
     {
         app.displayCapitalCities(null);


### PR DESCRIPTION
Added the ByContinent() function to query all capital cities in a continent, sorted from largest to smallest population, and return only the number of cities equal to the N parameter provided.