### PR TITLE
Add SpecificPopulation.ByDistrict() Method to return the total population of people within a specific district

### DIFF
--- a/src/main/java/com/napier/sem/App.java
+++ b/src/main/java/com/napier/sem/App.java
@@ -174,6 +174,10 @@ public class App
         System.out.println("`````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````");
     }
 
+    /**
+     * Displays the population details in a formatted table
+     * @param populations The list of Population objects that will be displayed
+     */
     public void displayPopulations(ArrayList<Population> populations)
     {
         if (populations == null)
@@ -195,6 +199,11 @@ public class App
         System.out.println("`````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````");
     }
 
+    /**
+     * Displays the population details in a formatted table
+     * @param population The population object that will be displayed
+     * @param type The area type that population data will be displayed for - affects displayed columns
+     */
     public void displaySpecificPopulation(Population population, String type)
     {
         if (population == null)

--- a/src/main/java/com/napier/sem/App.java
+++ b/src/main/java/com/napier/sem/App.java
@@ -7,6 +7,7 @@ import com.napier.sem.View.Index;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.Scanner;
 
 public class App
@@ -194,7 +195,7 @@ public class App
         System.out.println("`````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````");
     }
 
-    public void displaySpecificPopulation(Population population)
+    public void displaySpecificPopulation(Population population, String type)
     {
         if (population == null)
         {
@@ -202,10 +203,20 @@ public class App
             return;
         }
 
-        System.out.printf("%-45s %-25s %-25s %-25s %-25s %-25s%n", "AreaName", "TotalPopulation", "PopulationInCities", "PopulationInCities(%)", "PopulationOutsideCities", "PopulationOutsideCities(%)");
+        String populationString;
 
-        String populationString = String.format("%-45s %-25s %-25s %-25s %-25s %-25s",
-                population.areaName, population.population, population.populationCities, population.populationCitiesPercentage, population.populationOutsideCities, population.populationOutsideCitiesPercentage);
+        if (!Objects.equals(type, "District") && !Objects.equals(type, "City")) {
+            System.out.printf("%-45s %-25s %-25s %-25s %-25s %-25s%n", "AreaName", "TotalPopulation", "PopulationInCities", "PopulationInCities(%)", "PopulationOutsideCities", "PopulationOutsideCities(%)");
+
+            populationString = String.format("%-45s %-25s %-25s %-25s %-25s %-25s",
+                    population.areaName, population.population, population.populationCities, population.populationCitiesPercentage, population.populationOutsideCities, population.populationOutsideCitiesPercentage);
+        } else {
+            System.out.printf("%-45s %-25s %n", "AreaName", "TotalPopulation");
+
+            populationString = String.format("%-45s %-25s",
+                    population.areaName, population.population);
+        }
+
         System.out.println(populationString);
 
         System.out.println("`````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````");

--- a/src/main/java/com/napier/sem/Features/SpecificPopulation.java
+++ b/src/main/java/com/napier/sem/Features/SpecificPopulation.java
@@ -4,49 +4,52 @@ import com.napier.sem.Helpers.ReportHelper;
 import com.napier.sem.Models.Population;
 import java.util.ArrayList;
 
-public class SpecificPopulation  {
+public class SpecificPopulation {
     private ReportHelper reportHelper;
 
-    public SpecificPopulation (ReportHelper reportHelper) {
+    public SpecificPopulation(ReportHelper reportHelper) {
         this.reportHelper = reportHelper;
     }
 
     /**
      * Gets a report of the total population of the world, including the number of people living within and outside of cities     *
+     *
      * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
      */
 
     public Population ByWorld() {
         return reportHelper.getSpecificPopulationReport("SELECT COALESCE(SUM(country.population), 0) AS TotalPopulation, COALESCE(SUM(city_population.population), 0) AS PopulationCities, (COALESCE(SUM(city_population.population), 0) / COALESCE(SUM(country.population), 0) * 100) AS PopulationCityPercentage, SUM(country.population) - COALESCE(SUM(city_population.population), 0) AS PopulationOutsideCities, ((SUM(country.population) - COALESCE(SUM(city_population.population), 0)) / COALESCE(SUM(country.population), 0) * 100) AS PopulationOutsideCityPercentage " +
-                "FROM country " +
-                "LEFT JOIN (SELECT CountryCode, SUM(population) AS population " +
-                "FROM city " +
-                "GROUP BY CountryCode) AS city_population ON country.Code = city_population.CountryCode "
-        , "World");
+                        "FROM country " +
+                        "LEFT JOIN (SELECT CountryCode, SUM(population) AS population " +
+                        "FROM city " +
+                        "GROUP BY CountryCode) AS city_population ON country.Code = city_population.CountryCode "
+                , "World");
     }
 
     /**
      * Gets a report of the total population of a specific continent, including the number of people living within and outside of cities     *
+     *
      * @param continent The name of the continent, constraining the population returned to within the specified continent
-     * * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
+     *                  * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
      */
 
     public Population ByContinent(String continent) {
         return reportHelper.getSpecificPopulationReport("SELECT country.continent AS AreaName, COALESCE(SUM(country.population), 0) AS TotalPopulation, COALESCE(SUM(city_population.population), 0) AS PopulationCities, (COALESCE(SUM(city_population.population), 0) / COALESCE(SUM(country.population), 0) * 100) AS PopulationCityPercentage, SUM(country.population) - COALESCE(SUM(city_population.population), 0) AS PopulationOutsideCities, ((SUM(country.population) - COALESCE(SUM(city_population.population), 0)) / COALESCE(SUM(country.population), 0) * 100) AS PopulationOutsideCityPercentage " +
-                        "FROM country " +
-                        "LEFT JOIN (SELECT CountryCode, SUM(city.population) AS population " +
-                        "FROM city " +
-                        "JOIN country ON city.CountryCode = country.Code " +
-                        "WHERE country.Continent = '" + continent + "' " +
-                        "GROUP BY CountryCode) AS city_population ON country.Code = city_population.CountryCode " +
-                        "WHERE country.continent = '" + continent  + "' " +
-                        "GROUP BY country.continent", "Continent");
+                "FROM country " +
+                "LEFT JOIN (SELECT CountryCode, SUM(city.population) AS population " +
+                "FROM city " +
+                "JOIN country ON city.CountryCode = country.Code " +
+                "WHERE country.Continent = '" + continent + "' " +
+                "GROUP BY CountryCode) AS city_population ON country.Code = city_population.CountryCode " +
+                "WHERE country.continent = '" + continent + "' " +
+                "GROUP BY country.continent", "Continent");
     }
 
     /**
      * Gets a report of the total population of a specific region, including the number of people living within and outside of cities     *
+     *
      * @param region The name of the region, constraining the population returned to within the specified region
-     * * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
+     *               * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
      */
 
     public Population ByRegion(String region) {
@@ -57,14 +60,15 @@ public class SpecificPopulation  {
                 "JOIN country ON city.CountryCode = country.Code " +
                 "WHERE country.Region = '" + region + "' " +
                 "GROUP BY CountryCode) AS city_population ON country.Code = city_population.CountryCode " +
-                "WHERE country.Region = '" + region  + "' " +
+                "WHERE country.Region = '" + region + "' " +
                 "GROUP BY country.Region", "Region");
     }
 
     /**
      * Gets a report of the total population of a specific country, including the number of people living within and outside of cities     *
+     *
      * @param country The name of the country, constraining the population returned to within the specified country
-     * * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
+     *                * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
      */
 
     public Population ByCountry(String country) {
@@ -75,7 +79,22 @@ public class SpecificPopulation  {
                 "JOIN country ON city.CountryCode = country.Code " +
                 "WHERE country.Name = '" + country + "' " +
                 "GROUP BY CountryCode) AS city_population ON country.Code = city_population.CountryCode " +
-                "WHERE country.Name = '" + country  + "' " +
+                "WHERE country.Name = '" + country + "' " +
                 "GROUP BY country.Name", "Country");
+    }
+
+    /**
+     * Gets a report of the total population of a specific district, including the number of people living within and outside of cities     *
+     *
+     * @param district The name of the country, constraining the population returned to within the specified district
+     * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
+     */
+
+    public Population ByDistrict(String district) {
+
+        return reportHelper.getSpecificPopulationReport("SELECT city.district AS AreaName, COALESCE(SUM(city.population), 0) AS TotalPopulation " +
+                "FROM city " +
+                "WHERE city.district = '" + district + "' " +
+                "GROUP BY city.district", "District");
     }
 }

--- a/src/main/java/com/napier/sem/Features/SpecificPopulation.java
+++ b/src/main/java/com/napier/sem/Features/SpecificPopulation.java
@@ -30,7 +30,7 @@ public class SpecificPopulation {
      * Gets a report of the total population of a specific continent, including the number of people living within and outside of cities     *
      *
      * @param continent The name of the continent, constraining the population returned to within the specified continent
-     *                  * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
+     * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
      */
 
     public Population ByContinent(String continent) {
@@ -49,7 +49,7 @@ public class SpecificPopulation {
      * Gets a report of the total population of a specific region, including the number of people living within and outside of cities     *
      *
      * @param region The name of the region, constraining the population returned to within the specified region
-     *               * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
+     * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
      */
 
     public Population ByRegion(String region) {
@@ -68,7 +68,7 @@ public class SpecificPopulation {
      * Gets a report of the total population of a specific country, including the number of people living within and outside of cities     *
      *
      * @param country The name of the country, constraining the population returned to within the specified country
-     *                * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
+     * @return a Population object that contains the respective properties : AreaName, Population, PopulationCities, PopulationOutsideCityPercentage PopulationOutsideCities, PopulationOutsideCityPercentage
      */
 
     public Population ByCountry(String country) {

--- a/src/main/java/com/napier/sem/Helpers/ReportHelper.java
+++ b/src/main/java/com/napier/sem/Helpers/ReportHelper.java
@@ -142,11 +142,15 @@ public class ReportHelper
                     population.areaName = rset.getString("AreaName");
                 }
 
+                if (!Objects.equals(type, "District") && !Objects.equals(type, "City")) {
+                    population.populationCities = rset.getLong("PopulationCities");
+                    population.populationCitiesPercentage = rset.getFloat("PopulationCityPercentage");
+                    population.populationOutsideCities = rset.getLong("PopulationOutsideCities");
+                    population.populationOutsideCitiesPercentage = rset.getFloat("PopulationOutsideCityPercentage");
+                }
+
                 population.population = rset.getLong("TotalPopulation");
-                population.populationCities = rset.getLong("PopulationCities");
-                population.populationCitiesPercentage = rset.getFloat("PopulationCityPercentage");
-                population.populationOutsideCities = rset.getLong("PopulationOutsideCities");
-                population.populationOutsideCitiesPercentage = rset.getFloat("PopulationOutsideCityPercentage");
+
             }
         }
         catch (Exception e)

--- a/src/main/java/com/napier/sem/Helpers/ReportHelper.java
+++ b/src/main/java/com/napier/sem/Helpers/ReportHelper.java
@@ -122,6 +122,7 @@ public class ReportHelper
     /**
      * Helper method to get the population information by using the SQL queries
      * @param strSelect SQL query that will return the population information needed for the reports
+     * @param type A string that denotes the area type that the query will be conducted for, affecting the resulting columns
      * @return Population object that contains the required data being fetched
      */
 

--- a/src/main/java/com/napier/sem/View/Index.java
+++ b/src/main/java/com/napier/sem/View/Index.java
@@ -81,6 +81,7 @@ public class Index {
         System.out.println("  27)  Display the total population, population of people within and outside of cities in a continent");
         System.out.println("  28)  Display the total population, population of people within and outside of cities in a region");
         System.out.println("  29)  Display the total population, population of people within and outside of cities in a country");
+        System.out.println("  30)  Display the total population, population of people within and outside of cities in a district");
     }
 
     /**
@@ -138,10 +139,11 @@ public class Index {
         keyValues.put("25", () -> app.displayPopulations(allPopulations.ByCountry()));
 
         //---------       Total population of people, within and outwith cities in a specific area type  ---------------
-        keyValues.put("26", () -> app.displaySpecificPopulation(specificPopulation.ByWorld()));
-        keyValues.put("27", () -> app.displaySpecificPopulation(specificPopulation.ByContinent(continent)));
-        keyValues.put("28", () -> app.displaySpecificPopulation(specificPopulation.ByRegion(region)));
-        keyValues.put("29", () -> app.displaySpecificPopulation(specificPopulation.ByCountry(country)));
+        keyValues.put("26", () -> app.displaySpecificPopulation(specificPopulation.ByWorld(), "World"));
+        keyValues.put("27", () -> app.displaySpecificPopulation(specificPopulation.ByContinent(continent), "Continent"));
+        keyValues.put("28", () -> app.displaySpecificPopulation(specificPopulation.ByRegion(region), "Region"));
+        keyValues.put("29", () -> app.displaySpecificPopulation(specificPopulation.ByCountry(country), "Country"));
+        keyValues.put("30", () -> app.displaySpecificPopulation(specificPopulation.ByDistrict(district), "District"));
 
         return keyValues.getOrDefault(choice, () -> System.out.println("Invalid choice."));
     }

--- a/src/test/java/com/napier/sem/AppTest.java
+++ b/src/test/java/com/napier/sem/AppTest.java
@@ -163,14 +163,14 @@ public class AppTest
     @Test
     void printSpecificPopulationTestNull()
     {
-        app.displaySpecificPopulation(null);
+        app.displaySpecificPopulation(null, "World");
     }
 
     @Test
     void printSpecificPopulationTestEmpty()
     {
         Population population = new Population();
-        app.displaySpecificPopulation(population);
+        app.displaySpecificPopulation(population, "World");
     }
 
     @Test
@@ -184,6 +184,6 @@ public class AppTest
         population.populationOutsideCities = 1500000;
         population.populationOutsideCitiesPercentage = 50.00F;
 
-        app.displaySpecificPopulation(population);
+        app.displaySpecificPopulation(population, "Country");
     }
 }


### PR DESCRIPTION
Added the ByDistrict() method to query the total population for a specific district. 

It does not display how many people live within/outwith cities within a district as there is no way to discern this information using the existing db tables. The only information we have about district population is using the population of cities within that district.

The displaySpecificPopulation function has now been updated to discern whether the function is running on a district or city, and when it is, only attempt populate and display the AreaName and TotalPopulation columns.